### PR TITLE
Add GET /api/ideasessions/{id} endpoint with steps and authorization

### DIFF
--- a/API-Layer/API-Layer.csproj
+++ b/API-Layer/API-Layer.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
@@ -16,10 +17,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Controllers\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/API-Layer/Controllers/IdeaSessionsController.cs
+++ b/API-Layer/Controllers/IdeaSessionsController.cs
@@ -1,0 +1,33 @@
+﻿using Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace API_Layer.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class IdeaSessionsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public IdeaSessionsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetIdeaSessionById(Guid id)
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+            return Unauthorized();
+
+        var result = await _mediator.Send(new GetIdeaSessionByIdQuery(id, userId));
+
+        return result is null ? NotFound() : Ok(result);
+    }
+}

--- a/API-Layer/Program.cs
+++ b/API-Layer/Program.cs
@@ -1,12 +1,15 @@
+using Application_Layer;
+using Application_Layer.Common.Mappings;
+using Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+using Domain_Layer.Models;
+using Infrastructure_Layer;
+using Infrastructure_Layer.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using Infrastructure_Layer.Data;
-using Infrastructure_Layer;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
-using Domain_Layer.Models;
-using Application_Layer;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +18,12 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddApplicationServices(builder.Configuration);
+builder.Services.AddAutoMapper(typeof(MappingProfile).Assembly);
 
+builder.Services.AddMediatR(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(typeof(GetIdeaSessionByIdHandler).Assembly);
+});
 builder.Services.AddIdentity<UserModel, IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultTokenProviders();

--- a/Application-Layer/Application-Layer.csproj
+++ b/Application-Layer/Application-Layer.csproj
@@ -2,9 +2,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Domain-Layer\Domain-Layer.csproj" />
+    <ProjectReference Include="..\Infrastructure-Layer\Infrastructure-Layer.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
   </ItemGroup>
 

--- a/Application-Layer/Common/Mappings/MappingProfile.cs
+++ b/Application-Layer/Common/Mappings/MappingProfile.cs
@@ -1,0 +1,19 @@
+﻿using Application_Layer.IdeaSessions.DTOs;
+using AutoMapper;
+using Domain_Layer.Models;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace Application_Layer.Common.Mappings;
+
+public class MappingProfile : Profile
+{
+    public MappingProfile()
+    {
+        CreateMap<IdeaSession, IdeaSessionWithStepsDto>()
+            .ForMember(dest => dest.IdeaId, opt => opt.MapFrom(src => src.Id))
+            .ForMember(dest => dest.Steps, static opt => opt.MapFrom(src => src.Steps.OrderBy(s => s.StepOrder)));
+
+        CreateMap<Step, StepDto>()
+            .ForMember(dest => dest.StepId, opt => opt.MapFrom(src => src.Id));
+    }
+}

--- a/Application-Layer/IdeaSessions/DTOs/IdeaSessionWithStepsDto.cs
+++ b/Application-Layer/IdeaSessions/DTOs/IdeaSessionWithStepsDto.cs
@@ -1,0 +1,11 @@
+﻿namespace Application_Layer.IdeaSessions.DTOs;
+
+public class IdeaSessionWithStepsDto
+{
+    public Guid IdeaId { get; set; }
+    public string Title { get; set; } = default!;
+    public string Status { get; set; } = default!;
+    public DateTime CreatedAt { get; set; }
+
+    public List<StepDto> Steps { get; set; } = new();
+}

--- a/Application-Layer/IdeaSessions/DTOs/StepDto.cs
+++ b/Application-Layer/IdeaSessions/DTOs/StepDto.cs
@@ -1,0 +1,10 @@
+﻿namespace Application_Layer.IdeaSessions.DTOs;
+
+public class StepDto
+{
+    public Guid StepId { get; set; }
+    public int StepTemplateId { get; set; }
+    public string? UserInput { get; set; }
+    public string? AiResponse { get; set; }
+    public int StepOrder { get; set; }
+}

--- a/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdHandler.cs
+++ b/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdHandler.cs
@@ -1,0 +1,29 @@
+﻿using Application_Layer.IdeaSessions.DTOs;
+using AutoMapper;
+using Domain_Layer.Models;
+using Infrastructure_Layer.Data;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+
+public class GetIdeaSessionByIdHandler : IRequestHandler<GetIdeaSessionByIdQuery, IdeaSessionWithStepsDto?>
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public GetIdeaSessionByIdHandler(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<IdeaSessionWithStepsDto?> Handle(GetIdeaSessionByIdQuery request, CancellationToken cancellationToken)
+    {
+        var idea = await _context.IdeaSessions
+            .Include(i => i.Steps.OrderBy(s => s.StepOrder))
+            .FirstOrDefaultAsync(i => i.Id == request.IdeaId && i.UserId == request.UserId, cancellationToken);
+
+        return idea == null ? null : _mapper.Map<IdeaSessionWithStepsDto>(idea);
+    }
+}

--- a/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdQuery.cs
+++ b/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdQuery.cs
@@ -1,0 +1,16 @@
+﻿using Application_Layer.IdeaSessions.DTOs;
+using MediatR;
+
+namespace Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+
+public class GetIdeaSessionByIdQuery : IRequest<IdeaSessionWithStepsDto?>
+{
+    public Guid IdeaId { get; }
+    public Guid UserId { get; }
+
+    public GetIdeaSessionByIdQuery(Guid ideaId, Guid userId)
+    {
+        IdeaId = ideaId;
+        UserId = userId;
+    }
+}

--- a/Domain-Layer/Models/Step.cs
+++ b/Domain-Layer/Models/Step.cs
@@ -16,5 +16,6 @@ namespace Domain_Layer.Models
         // Navigation properties
         public IdeaSession IdeaSession { get; set; }
         public StepTemplate StepTemplate { get; set; }
+        public object StepOrder { get; set; }
     }
 }


### PR DESCRIPTION
🧠 GET /api/ideasessions/{id} – Return idea session with steps
✅ What’s implemented
New authenticated GET endpoint:
GET /api/ideasessions/{id}

Returns idea session data only if it belongs to the current user

Returns full details:
ideaId, title, status, createdAt

Includes all related Steps, ordered by stepOrder

Returns 404 Not Found if:

idea session doesn’t exist

idea session doesn’t belong to user

AutoMapper mapping added

MediatR Query + Handler structure added

DTOs separated for clean response handling

Controller updated under IdeaSessionsController

🔐 Authorization
Endpoint requires a valid JWT

UserId extracted from claims to secure access

📦 Affected areas
Application-Layer/IdeaSessions/DTOs/

Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/

Application-Layer/Common/Mappings/

API-Layer/Controllers/IdeaSessionsController.cs

Program.cs: MediatR registration updated for v12 syntax

🧪 To test
Login to get a valid JWT

Make a request like:
GET /api/ideasessions/{id}
with a valid idea session ID belonging to your user

Verify:

Correct data structure

Steps are ordered by stepOrder

404 is returned for unauthorized or non-existing IDs