### PR TITLE
GET /api/ideasessions/{id}

### DIFF
--- a/API-Layer/Controllers/IdeaSessionsController.cs
+++ b/API-Layer/Controllers/IdeaSessionsController.cs
@@ -1,0 +1,33 @@
+﻿using Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace API_Layer.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class IdeaSessionsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public IdeaSessionsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+            return Unauthorized();
+
+        var result = await _mediator.Send(new GetIdeaSessionByIdQuery(id, userId));
+
+        return result is null ? NotFound() : Ok(result);
+    }
+}

--- a/Application-Layer/Common/Mappings/DataMappings.cs
+++ b/Application-Layer/Common/Mappings/DataMappings.cs
@@ -1,15 +1,24 @@
 ﻿using Application_Layer.UserAuth.Dtos;
-using Domain_Layer.Models;
+using Application_Layer.IdeaSessions.DTOs;
 using AutoMapper;
+using Domain_Layer.Models;
 
 namespace Application_Layer.Common.Mappings
 {
     public class DataMappings : Profile
     {
-        public DataMappings() 
+        public DataMappings()
         {
+            // Användare
             CreateMap<UserModel, UserDataDto>().ReverseMap();
+
+            // Idé-session med steg
+            CreateMap<IdeaSession, IdeaSessionWithStepsDto>()
+                .ForMember(dest => dest.IdeaId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dest => dest.Steps, opt => opt.MapFrom(src => src.Steps.OrderBy(s => s.StepOrder)));
+
+            CreateMap<Step, StepDto>()
+                .ForMember(dest => dest.StepId, opt => opt.MapFrom(src => src.Id));
         }
-        
     }
 }

--- a/Application-Layer/Common/Mappings/DataMappings.cs
+++ b/Application-Layer/Common/Mappings/DataMappings.cs
@@ -15,10 +15,12 @@ namespace Application_Layer.Common.Mappings
             // Idé-session med steg
             CreateMap<IdeaSession, IdeaSessionWithStepsDto>()
                 .ForMember(dest => dest.IdeaId, opt => opt.MapFrom(src => src.Id))
-                .ForMember(dest => dest.Steps, opt => opt.MapFrom(src => src.Steps.OrderBy(s => s.StepOrder)));
+                .ForMember(dest => dest.Steps, opt => opt.MapFrom(src => src.Steps.OrderBy(s => s.Order)));
 
             CreateMap<Step, StepDto>()
-                .ForMember(dest => dest.StepId, opt => opt.MapFrom(src => src.Id));
+    .ForMember(dest => dest.StepId, opt => opt.MapFrom(src => src.Id))
+    .ForMember(dest => dest.Order, opt => opt.MapFrom(src => src.Order));
+
         }
     }
 }

--- a/Application-Layer/IdeaSessions/DTOs/IdeaSessionWithStepsDto.cs
+++ b/Application-Layer/IdeaSessions/DTOs/IdeaSessionWithStepsDto.cs
@@ -1,0 +1,11 @@
+﻿namespace Application_Layer.IdeaSessions.DTOs;
+
+public class IdeaSessionWithStepsDto
+{
+    public Guid IdeaId { get; set; }
+    public string Title { get; set; } = default!;
+    public string Status { get; set; } = default!;
+    public DateTime CreatedAt { get; set; }
+
+    public List<StepDto> Steps { get; set; } = new();
+}

--- a/Application-Layer/IdeaSessions/DTOs/StepDto.cs
+++ b/Application-Layer/IdeaSessions/DTOs/StepDto.cs
@@ -6,5 +6,5 @@ public class StepDto
     public int StepTemplateId { get; set; }
     public string? UserInput { get; set; }
     public string? AiResponse { get; set; }
-    public int StepOrder { get; set; }
+    public int Order { get; set; }
 }

--- a/Application-Layer/IdeaSessions/DTOs/StepDto.cs
+++ b/Application-Layer/IdeaSessions/DTOs/StepDto.cs
@@ -1,0 +1,10 @@
+﻿namespace Application_Layer.IdeaSessions.DTOs;
+
+public class StepDto
+{
+    public Guid StepId { get; set; }
+    public int StepTemplateId { get; set; }
+    public string? UserInput { get; set; }
+    public string? AiResponse { get; set; }
+    public int StepOrder { get; set; }
+}

--- a/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdHandler.cs
+++ b/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdHandler.cs
@@ -1,0 +1,44 @@
+﻿using Application_Layer.Common.Interfaces;
+using Application_Layer.IdeaSessions.DTOs;
+using AutoMapper;
+using Domain_Layer.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+
+public class GetIdeaSessionByIdHandler : IRequestHandler<GetIdeaSessionByIdQuery, IdeaSessionWithStepsDto?>
+{
+    private readonly IGenericRepository<IdeaSession> _ideaRepository;
+    private readonly IGenericRepository<Step> _stepRepository;
+    private readonly IMapper _mapper;
+
+    public GetIdeaSessionByIdHandler(
+        IGenericRepository<IdeaSession> ideaRepository,
+        IGenericRepository<Step> stepRepository,
+        IMapper mapper)
+    {
+        _ideaRepository = ideaRepository;
+        _stepRepository = stepRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<IdeaSessionWithStepsDto?> Handle(GetIdeaSessionByIdQuery request, CancellationToken cancellationToken)
+    {
+        var idea = await _ideaRepository.GetByIdAsync(request.IdeaId);
+
+        if (idea == null || idea.UserId != request.UserId)
+            return null;
+
+        // Hämta steps separat eftersom Include() inte finns
+        var steps = await _stepRepository.GetAllAsync();
+        var matchingSteps = steps
+            .Where(s => s.IdeaSessionId == idea.Id)
+            .OrderBy(s => s.StepOrder)
+            .ToList();
+
+        idea.Steps = matchingSteps;
+
+        return _mapper.Map<IdeaSessionWithStepsDto>(idea);
+    }
+}

--- a/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdHandler.cs
+++ b/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdHandler.cs
@@ -34,7 +34,7 @@ public class GetIdeaSessionByIdHandler : IRequestHandler<GetIdeaSessionByIdQuery
         var steps = await _stepRepository.GetAllAsync();
         var matchingSteps = steps
             .Where(s => s.IdeaSessionId == idea.Id)
-            .OrderBy(s => s.StepOrder)
+            .OrderBy(s => s.Order)
             .ToList();
 
         idea.Steps = matchingSteps;

--- a/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdQuery.cs
+++ b/Application-Layer/IdeaSessions/Queries/GetIdeaSessionById/GetIdeaSessionByIdQuery.cs
@@ -1,0 +1,16 @@
+﻿using Application_Layer.IdeaSessions.DTOs;
+using MediatR;
+
+namespace Application_Layer.IdeaSessions.Queries.GetIdeaSessionById;
+
+public class GetIdeaSessionByIdQuery : IRequest<IdeaSessionWithStepsDto?>
+{
+    public Guid IdeaId { get; }
+    public Guid UserId { get; }
+
+    public GetIdeaSessionByIdQuery(Guid ideaId, Guid userId)
+    {
+        IdeaId = ideaId;
+        UserId = userId;
+    }
+}

--- a/Domain-Layer/Models/Step.cs
+++ b/Domain-Layer/Models/Step.cs
@@ -16,6 +16,5 @@ namespace Domain_Layer.Models
         // Navigation properties
         public IdeaSession IdeaSession { get; set; }
         public StepTemplate StepTemplate { get; set; }
-        public object StepOrder { get; set; }
     }
 }

--- a/Domain-Layer/Models/Step.cs
+++ b/Domain-Layer/Models/Step.cs
@@ -16,5 +16,6 @@ namespace Domain_Layer.Models
         // Navigation properties
         public IdeaSession IdeaSession { get; set; }
         public StepTemplate StepTemplate { get; set; }
+        public object StepOrder { get; set; }
     }
 }


### PR DESCRIPTION
🎯 GET /api/ideasessions/{id} – Fetch specific idea session with steps
✅ What’s implemented
New GET endpoint:
GET /api/ideasessions/{id}

Returns a single idea session only if owned by the authenticated user

Includes full idea info: ideaId, title, status, createdAt

Returns all related Steps, sorted by stepOrder

Returns 404 Not Found if idea session doesn’t exist or doesn’t belong to user

Uses JWT authentication to extract UserId from claims

🧱 Architecture
Clean Architecture (CQRS with MediatR)

Uses IGenericRepository<IdeaSession> and IGenericRepository<Step>

AutoMapper for mapping to IdeaSessionWithStepsDto

Separated DTO layer

🔐 Authorization
Endpoint is protected via [Authorize]

Access allowed only for idea session owners

🧪 How to test
Authenticate and retrieve JWT

Make a request to:
GET /api/ideasessions/{id}

✅ If session exists and belongs to user → returns full idea with steps
❌ Else → returns 404